### PR TITLE
CE blub mentions award, made opening on main page past tense

### DIFF
--- a/content/calculating-empires/intro.md
+++ b/content/calculating-empires/intro.md
@@ -2,8 +2,7 @@
  
  ###### —Gregory Bateson, 1972
 
-
-**[Calculating Empires](https://calculatingempires.net/)** is a new exhibition by Kate Crawford and Vladan Joler that opens at Fondazione Prada on November 23, 2023 at the Osservatorio in Milan. Joler and Crawford contextualize the current explosion of artificial intelligence by asking how we got here — and to consider where we might be going. Multiple works of critical cartography span the two floors, 
+**[Calculating Empires](https://calculatingempires.net/)** is a new exhibition by Kate Crawford and Vladan Joler that opened at Fondazione Prada on November 23, 2023 at the Osservatorio in Milan. Joler and Crawford contextualize the current explosion of artificial intelligence by asking how we got here — and to consider where we might be going. Multiple works of critical cartography span the two floors. 
 
 The centerpiece of the exhibition is the *Calculating Empires* Map Room. The viewer is invited to enter a dark room, like walking into a literal black box, to find an intricately detailed space. This immersive work is presented to the public for the first time and is based on a diptych of maps: one speaks to the themes of *communication and computation*, the other explores *control and classification*. Each map is over 12 meters long and depicts how empires have calculated  —and how we might calculate empires —  over a five hundred year time span. 
 

--- a/data/publications.json
+++ b/data/publications.json
@@ -1,5 +1,19 @@
 [
   {
+    "href": "/knowing-legal-machines/calculating-empires",
+    "slug": "calculating-empires",
+    "contentPath": "calculating-empires",
+    "contentType": "Exhibition",
+    "coverImg": "/img/calculating_empires/0.png",
+    "coverImgAlt": "Section of the map Calculating empires",
+    "title": "Calculating Empires",
+    "preposition": "Written by",
+    "intro": "/content/calculating-empires/intro.md",
+    "authors": "Kate Crawford and Vladan Joler",
+    "excerpt": "Calculating Empires has won the European Commission's 2024 Grand Prize for Artistic Exploration in Science, Technology, and the Arts. The jury noted that 'Calculating Empires challenges us to redefine our relationship with current socio-technical structures. By asking how we got where we are today, we can reconsider where we might be going.' Previous winners include Richard Mosse, Holly Herndon and Matt Dryhurst.",
+    "external": false
+  },
+  {
     "href": "/models-all-the-way",
     "contentType": "Visual Story",
     "coverImg": "/img/models_all_the_way.png",
@@ -22,20 +36,6 @@
     "intro": "/content/synthetic-media-media/intro.md",
     "authors": "Mike Ananny and Jake Karr",
     "excerpt": "This project traces how media systems are using, interpreting, and anticipating Generative AI to create public life. We’re studying how the news industry frames Generative AI, when and why journalists are using it in their work, which policies and guidelines organizations are creating to regulate its use, and how people and infrastructures have the power to make Generative AI a public problem.",
-    "external": false
-  },
-  {
-    "href": "/knowing-legal-machines/calculating-empires",
-    "slug": "calculating-empires",
-    "contentPath": "calculating-empires",
-    "contentType": "Exhibition",
-    "coverImg": "/img/calculating_empires/0.png",
-    "coverImgAlt": "Section of the map Calculating empires",
-    "title": "Calculating Empires",
-    "preposition": "Written by",
-    "intro": "/content/calculating-empires/intro.md",
-    "authors": "Kate Crawford and Vladan Joler",
-    "excerpt": "Calculating Empires is a new exhibition by Kate Crawford and Vladan Joler that opens at Fondazione Prada on November 23, 2023 at the Osservatorio in Milan. Joler and Crawford contextualize the current explosion of artificial intelligence by asking how we got here — and to consider where we might be going. Multiple works of critical cartography span the two floors, and invite visitors to experience the longue durée of how technology and power have been intertwined since 1500. ",
     "external": false
   },
   {


### PR DESCRIPTION
1. Moved CE to the top of the home page,
2. The home page blurb for CE now focuses on the Artistic Exploration in Science, Technology, and the Arts award
3. The references to the 2023 premier on the main EC page (intro.md) are now in the past tense 